### PR TITLE
Create Unity package structure with catalog runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## [0.1.0] - 2024-01-01
+- Initial package structure and runtime catalog utilities.

--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 71cb6d619e4a4a91b123a3cc476ba430
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# Jungle-Catalog
-A catalog framework for Unity for storing and retrieving data easily
+# Jungle Catalog
+
+Runtime catalog utilities for Jungle packages.
+
+## Installation
+
+Use Unity's Package Manager to add the Git URL for this repository or include the folder inside your project `Packages` directory.
+
+This package depends on **Jungle Core**. Ensure `jungle.core` is installed or referenced in your project manifest.
+
+## Usage
+
+1. Create a catalog asset that derives from `CatalogAsset<TItem>`.
+2. Implement catalog items by inheriting from `CatalogItem` and providing a unique identifier.
+3. Populate the catalog asset in the inspector and access entries at runtime via `CatalogAsset.Get` / `TryGet`.
+
+The runtime API enforces unique identifiers and provides helpful exceptions when configuration is invalid, making catalog data reliable across projects.

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 43d03c66d3d54493ac4d5dcfdfcbc070
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime.meta
+++ b/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a3ecfdaeaae549efa37b1916fd50b624
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Catalog.meta
+++ b/Runtime/Catalog.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c08c9bc490b46688d3ef65b092c9aa3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Catalog/CatalogAsset.cs
+++ b/Runtime/Catalog/CatalogAsset.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Jungle.Catalog
+{
+    /// <summary>
+    /// ScriptableObject storing catalog items and providing fast lookup by identifier.
+    /// </summary>
+    /// <typeparam name="TItem">Type of item stored in the catalog.</typeparam>
+    public abstract class CatalogAsset<TItem> : ScriptableObject where TItem : CatalogItem
+    {
+        [SerializeField]
+        private List<TItem> items = new();
+
+        private Dictionary<string, TItem> lookup;
+
+        /// <summary>
+        /// Items stored in the catalog.
+        /// </summary>
+        public IReadOnlyList<TItem> Items => items;
+
+        private void OnEnable()
+        {
+            RefreshLookup();
+        }
+
+        /// <summary>
+        /// Rebuilds the lookup dictionary, validating identifiers and duplicates.
+        /// </summary>
+        public void RefreshLookup()
+        {
+            lookup = BuildLookup();
+        }
+
+        /// <summary>
+        /// Returns the catalog item for the provided identifier.
+        /// </summary>
+        /// <param name="id">Identifier of the item.</param>
+        /// <returns>Catalog item associated with the identifier.</returns>
+        /// <exception cref="ArgumentException">Thrown when the identifier is null or whitespace.</exception>
+        /// <exception cref="KeyNotFoundException">Thrown when the identifier is not present.</exception>
+        public TItem Get(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException("Catalog id must be provided.", nameof(id));
+            }
+
+            if (TryGet(id, out var item))
+            {
+                return item;
+            }
+
+            throw new KeyNotFoundException($"Catalog '{name}' does not contain an item with id '{id}'.");
+        }
+
+        /// <summary>
+        /// Attempts to retrieve an item by identifier.
+        /// </summary>
+        /// <param name="id">Identifier of the item.</param>
+        /// <param name="item">When the method returns, contains the matched item if found.</param>
+        /// <returns>True when the identifier exists in the catalog.</returns>
+        public bool TryGet(string id, out TItem item)
+        {
+            if (lookup == null)
+            {
+                RefreshLookup();
+            }
+
+            return lookup.TryGetValue(id, out item);
+        }
+
+        private Dictionary<string, TItem> BuildLookup()
+        {
+            var dictionary = new Dictionary<string, TItem>(items.Count);
+            for (var index = 0; index < items.Count; index++)
+            {
+                var entry = items[index];
+                if (entry == null)
+                {
+                    throw new InvalidOperationException($"Catalog '{name}' contains an unassigned item at index {index}.");
+                }
+
+                entry.EnsureConfigured();
+
+                if (dictionary.ContainsKey(entry.Id))
+                {
+                    throw new InvalidOperationException($"Catalog '{name}' contains duplicate id '{entry.Id}'.");
+                }
+
+                dictionary.Add(entry.Id, entry);
+            }
+
+            return dictionary;
+        }
+    }
+}

--- a/Runtime/Catalog/CatalogAsset.cs.meta
+++ b/Runtime/Catalog/CatalogAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d06753936af4a2d8d8ea1b5eb81556f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Catalog/CatalogItem.cs
+++ b/Runtime/Catalog/CatalogItem.cs
@@ -1,0 +1,61 @@
+using System;
+using UnityEngine;
+
+namespace Jungle.Catalog
+{
+    /// <summary>
+    /// Base ScriptableObject for catalog entries.
+    /// </summary>
+    public abstract class CatalogItem : ScriptableObject, ICatalogItem
+    {
+        [SerializeField]
+        private string id = string.Empty;
+
+        [SerializeField]
+        private string displayName = string.Empty;
+
+        /// <inheritdoc />
+        public string Id => id;
+
+        /// <inheritdoc />
+        public string DisplayName => string.IsNullOrWhiteSpace(displayName) ? id : displayName;
+
+#if UNITY_EDITOR
+        protected virtual void OnValidate()
+        {
+            if (!string.IsNullOrWhiteSpace(id))
+            {
+                id = id.Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(displayName))
+            {
+                displayName = displayName.Trim();
+            }
+        }
+#endif
+
+        /// <summary>
+        /// Ensures the item identifier is set. Throws if empty to help authoring workflows.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when the identifier is empty.</exception>
+        public void EnsureConfigured()
+        {
+            if (!string.IsNullOrWhiteSpace(id))
+            {
+                return;
+            }
+
+            throw new InvalidOperationException($"Catalog item '{name}' on asset '{GetAssetPath()}' is missing an identifier.");
+        }
+
+        private string GetAssetPath()
+        {
+#if UNITY_EDITOR
+            return UnityEditor.AssetDatabase.GetAssetPath(this);
+#else
+            return name;
+#endif
+        }
+    }
+}

--- a/Runtime/Catalog/CatalogItem.cs.meta
+++ b/Runtime/Catalog/CatalogItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd9254595eaf475db55b57efa876143a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Catalog/CatalogService.cs
+++ b/Runtime/Catalog/CatalogService.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jungle.Catalog
+{
+    /// <summary>
+    /// Runtime registry for catalog assets. Enables quick access to catalogs without manual wiring.
+    /// </summary>
+    public static class CatalogService
+    {
+        private static readonly Dictionary<Type, object> catalogs = new();
+
+        /// <summary>
+        /// Registers the provided catalog asset.
+        /// </summary>
+        /// <typeparam name="TItem">Type of items stored within the catalog.</typeparam>
+        /// <param name="catalog">Catalog asset to register.</param>
+        public static void Register<TItem>(CatalogAsset<TItem> catalog) where TItem : CatalogItem
+        {
+            ArgumentNullException.ThrowIfNull(catalog);
+
+            catalogs[typeof(TItem)] = catalog;
+        }
+
+        /// <summary>
+        /// Attempts to retrieve a registered catalog.
+        /// </summary>
+        /// <typeparam name="TItem">Type of items stored within the catalog.</typeparam>
+        /// <param name="catalog">Retrieved catalog instance when available.</param>
+        /// <returns>True if the catalog is registered.</returns>
+        public static bool TryGetCatalog<TItem>(out CatalogAsset<TItem> catalog) where TItem : CatalogItem
+        {
+            if (catalogs.TryGetValue(typeof(TItem), out var stored) && stored is CatalogAsset<TItem> typed)
+            {
+                catalog = typed;
+                return true;
+            }
+
+            catalog = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Gets a registered catalog or throws when missing.
+        /// </summary>
+        /// <typeparam name="TItem">Type of items stored within the catalog.</typeparam>
+        /// <returns>The registered catalog asset.</returns>
+        public static CatalogAsset<TItem> GetCatalog<TItem>() where TItem : CatalogItem
+        {
+            if (TryGetCatalog<TItem>(out var catalog))
+            {
+                return catalog;
+            }
+
+            throw new InvalidOperationException($"Catalog for item type '{typeof(TItem).Name}' has not been registered.");
+        }
+
+        /// <summary>
+        /// Clears all registered catalogs. Useful for unit tests.
+        /// </summary>
+        public static void Clear()
+        {
+            catalogs.Clear();
+        }
+    }
+}

--- a/Runtime/Catalog/CatalogService.cs.meta
+++ b/Runtime/Catalog/CatalogService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d9aa00fcff141c5a1477644bc93dbd9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Catalog/ICatalogItem.cs
+++ b/Runtime/Catalog/ICatalogItem.cs
@@ -1,0 +1,18 @@
+namespace Jungle.Catalog
+{
+    /// <summary>
+    /// Base contract for catalog entries. Items stored in a catalog must expose a unique identifier.
+    /// </summary>
+    public interface ICatalogItem
+    {
+        /// <summary>
+        /// Unique identifier of the item within the catalog.
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
+        /// Optional friendly name displayed in tooling.
+        /// </summary>
+        string DisplayName { get; }
+    }
+}

--- a/Runtime/Catalog/ICatalogItem.cs.meta
+++ b/Runtime/Catalog/ICatalogItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d42587ade0ee4c7cb204c37727c0f6d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Jungle.Catalog.asmdef
+++ b/Runtime/Jungle.Catalog.asmdef
@@ -1,0 +1,13 @@
+{
+  "name": "Jungle.Catalog",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Runtime/Jungle.Catalog.asmdef.meta
+++ b/Runtime/Jungle.Catalog.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aaab3b09731b41479704a6d1e6d33be0
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "jungle.catalog",
+  "displayName": "Jungle Catalog",
+  "description": "Runtime catalog framework for the Jungle ecosystem with data lookup utilities.",
+  "version": "0.1.0",
+  "unity": "2021.3",
+  "unityRelease": "0f1",
+  "dependencies": {
+    "jungle.core": "1.0.0"
+  },
+  "keywords": [
+    "jungle",
+    "catalog",
+    "data"
+  ],
+  "author": {
+    "name": "Jungle Collective"
+  }
+}

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d4cbc8e3cb9345918f7a02f2ded5ba4b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add package.json with Jungle Core dependency and package metadata
- introduce runtime catalog API (items, asset base, registry service)
- document usage and changelog for the initial 0.1.0 release

## Testing
- not run (no automated tests available)


------
https://chatgpt.com/codex/tasks/task_e_68d0665869348320a3e36fa61cf08708