### PR TITLE
Add catalog entry implementations for common Unity types

### DIFF
--- a/Runtime/Catalog/Implementations/AudioClipCatalogEntry.cs
+++ b/Runtime/Catalog/Implementations/AudioClipCatalogEntry.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Jungle.Catalog.Implementations;
+using UnityEngine;
+
+namespace Plugins.Jungle_Catalog.Runtime.Catalog.Implementations
+{
+    [Serializable]
+    public class AudioClipCatalogEntry : GenericCatalogEntry<AudioClip, List<AudioClip>>
+    {
+    }
+}

--- a/Runtime/Catalog/Implementations/ColliderCatalogEntry.cs
+++ b/Runtime/Catalog/Implementations/ColliderCatalogEntry.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Jungle.Catalog.Implementations;
+using UnityEngine;
+
+namespace Plugins.Jungle_Catalog.Runtime.Catalog.Implementations
+{
+    [Serializable]
+    public class ColliderCatalogEntry : GenericCatalogEntry<Collider, List<Collider>>
+    {
+    }
+}

--- a/Runtime/Catalog/Implementations/ComponentCatalogEntry.cs
+++ b/Runtime/Catalog/Implementations/ComponentCatalogEntry.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Jungle.Catalog.Implementations;
+using UnityEngine;
+
+namespace Plugins.Jungle_Catalog.Runtime.Catalog.Implementations
+{
+    [Serializable]
+    public class ComponentCatalogEntry : GenericCatalogEntry<Component, List<Component>>
+    {
+    }
+}

--- a/Runtime/Catalog/Implementations/MaterialCatalogEntry.cs
+++ b/Runtime/Catalog/Implementations/MaterialCatalogEntry.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Jungle.Catalog.Implementations;
+using UnityEngine;
+
+namespace Plugins.Jungle_Catalog.Runtime.Catalog.Implementations
+{
+    [Serializable]
+    public class MaterialCatalogEntry : GenericCatalogEntry<Material, List<Material>>
+    {
+    }
+}

--- a/Runtime/Catalog/Implementations/MeshRendererCatalogEntry.cs
+++ b/Runtime/Catalog/Implementations/MeshRendererCatalogEntry.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Jungle.Catalog.Implementations;
+using UnityEngine;
+
+namespace Plugins.Jungle_Catalog.Runtime.Catalog.Implementations
+{
+    [Serializable]
+    public class MeshRendererCatalogEntry : GenericCatalogEntry<MeshRenderer, List<MeshRenderer>>
+    {
+    }
+}

--- a/Runtime/Catalog/Implementations/RigidbodyCatalogEntry.cs
+++ b/Runtime/Catalog/Implementations/RigidbodyCatalogEntry.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Jungle.Catalog.Implementations;
+using UnityEngine;
+
+namespace Plugins.Jungle_Catalog.Runtime.Catalog.Implementations
+{
+    [Serializable]
+    public class RigidbodyCatalogEntry : GenericCatalogEntry<Rigidbody, List<Rigidbody>>
+    {
+    }
+}

--- a/Runtime/Catalog/Implementations/ScriptableObjectCatalogEntry.cs
+++ b/Runtime/Catalog/Implementations/ScriptableObjectCatalogEntry.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Jungle.Catalog.Implementations;
+using UnityEngine;
+
+namespace Plugins.Jungle_Catalog.Runtime.Catalog.Implementations
+{
+    [Serializable]
+    public class ScriptableObjectCatalogEntry : GenericCatalogEntry<ScriptableObject, List<ScriptableObject>>
+    {
+    }
+}

--- a/Runtime/Catalog/Implementations/SpriteCatalogEntry.cs
+++ b/Runtime/Catalog/Implementations/SpriteCatalogEntry.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Jungle.Catalog.Implementations;
+using UnityEngine;
+
+namespace Plugins.Jungle_Catalog.Runtime.Catalog.Implementations
+{
+    [Serializable]
+    public class SpriteCatalogEntry : GenericCatalogEntry<Sprite, List<Sprite>>
+    {
+    }
+}

--- a/Runtime/Catalog/Implementations/TextureCatalogEntry.cs
+++ b/Runtime/Catalog/Implementations/TextureCatalogEntry.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Jungle.Catalog.Implementations;
+using UnityEngine;
+
+namespace Plugins.Jungle_Catalog.Runtime.Catalog.Implementations
+{
+    [Serializable]
+    public class TextureCatalogEntry : GenericCatalogEntry<Texture, List<Texture>>
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- add catalog entry implementations for AudioClip, Material, ScriptableObject, Sprite, Texture, Component, Collider, MeshRenderer, and Rigidbody types

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d19aaa1c4c83208af08142cdb934ee