### PR TITLE
Refactor catalog drawer to UI Toolkit

### DIFF
--- a/Editor/Resources/CatalogPropertyDrawer.uxml
+++ b/Editor/Resources/CatalogPropertyDrawer.uxml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements">
+    <ui:VisualElement class="jungle-catalog__root">
+        <ui:Foldout name="catalog-foldout" class="jungle-catalog__foldout" value="true">
+            <ui:VisualElement name="entries-container" class="jungle-catalog__entries" />
+            <ui:Button name="add-entry-button" text="Add Entry" class="jungle-btn--ghost jungle-catalog__add-button" />
+        </ui:Foldout>
+    </ui:VisualElement>
+</ui:UXML>

--- a/Editor/Resources/CatalogPropertyDrawer.uxml.meta
+++ b/Editor/Resources/CatalogPropertyDrawer.uxml.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dd3ba5c43477470d8df1c7dffd39fc02
+timeCreated: 1758568368

--- a/Editor/Resources/CatalogPropertyEntry.uxml
+++ b/Editor/Resources/CatalogPropertyEntry.uxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements">
+    <ui:VisualElement class="jungle-card jungle-catalog__entry">
+        <ui:VisualElement class="jungle-card__row jungle-catalog__entry-header">
+            <ui:Label name="entry-label" class="pkg-title jungle-catalog__entry-title" text="Entry" />
+            <ui:Button name="remove-entry-button" text="Remove" class="jungle-btn--ghost jungle-catalog__remove-button" />
+        </ui:VisualElement>
+        <ui:VisualElement name="entry-content" class="jungle-card__main jungle-catalog__entry-content" />
+    </ui:VisualElement>
+</ui:UXML>

--- a/Editor/Resources/CatalogPropertyEntry.uxml.meta
+++ b/Editor/Resources/CatalogPropertyEntry.uxml.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 300e827c76d54b9e83210b0fa071797e
+timeCreated: 1758568368


### PR DESCRIPTION
## Summary
- replace the IMGUI-based catalog property drawer with a UI Toolkit implementation built from UXML templates
- add catalog drawer and entry item UXML assets styled with the shared Jungle styling helpers
- invoke JungleStyling when constructing the drawer so shared USS resources are applied

## Testing
- not run (editor-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d19df9ceb48320b992b24630e03561